### PR TITLE
Chore/new image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.3
+FROM ruby:2.5.6
 
 RUN apt-get update
 RUN apt-get install build-essential default-mysql-client default-libmysqlclient-dev pv -y

--- a/api/puma.rb
+++ b/api/puma.rb
@@ -31,7 +31,7 @@ workers ENV.fetch("WEB_CONCURRENCY") { 8 }
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
 #
-# preload_app!
+preload_app!
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart

--- a/api/puma.rb
+++ b/api/puma.rb
@@ -24,7 +24,7 @@ environment ENV.fetch('RAILS_ENV', 'development')
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 8 }
+workers ENV.fetch("WEB_CONCURRENCY") { 8 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,8 @@ services:
       - mysqldb:mysqldb
     environment:
       WEB_CONCURRENCY: 6
-      RAILS_MAX_THREADS: 1
+      RAILS_MAX_THREADS: 5
+      RAILS_MIN_THREADS: 1
   web:
     image: nginx
     container_name: emastercard_nginx


### PR DESCRIPTION
changed the base from 2.5.3 to 2.5.6. 

This has fixed the issues with stalled processes and failing to build when on a freshly installed ubuntu 22.04 (not an upgrade)